### PR TITLE
fix: Revert theme to Material3 and Use AppCompatButton

### DIFF
--- a/Skeddly/app/src/main/res/layout/single_event_item.xml
+++ b/Skeddly/app/src/main/res/layout/single_event_item.xml
@@ -46,7 +46,7 @@
                 app:layout_constraintStart_toStartOf="parent"
                 app:layout_constraintTop_toTopOf="parent" />
 
-            <Button
+            <androidx.appcompat.widget.AppCompatButton
                 android:id="@+id/button_view_info"
                 android:layout_width="114dp"
                 android:layout_height="33dp"
@@ -57,11 +57,12 @@
                 android:insetTop="0dp"
                 android:insetBottom="0dp"
                 android:text="@string/button_view_info"
+                android:textAllCaps="false"
                 android:textColor="@color/secondary_dark_purple"
                 app:layout_constraintBottom_toBottomOf="parent"
                 app:layout_constraintStart_toStartOf="parent" />
 
-            <Button
+            <androidx.appcompat.widget.AppCompatButton
                 android:id="@+id/button_join"
                 android:layout_width="78dp"
                 android:layout_height="33dp"
@@ -72,11 +73,12 @@
                 android:insetTop="0dp"
                 android:insetBottom="0dp"
                 android:text="@string/button_join"
+                android:textAllCaps="false"
                 android:textColor="@color/neutral_lighter_off_white"
                 app:layout_constraintBottom_toBottomOf="parent"
                 app:layout_constraintEnd_toEndOf="parent" />
 
-            <Button
+            <androidx.appcompat.widget.AppCompatButton
                 android:id="@+id/button_edit"
                 android:layout_width="78dp"
                 android:layout_height="33dp"
@@ -87,6 +89,7 @@
                 android:insetTop="0dp"
                 android:insetBottom="0dp"
                 android:text="@string/button_edit"
+                android:textAllCaps="false"
                 android:textColor="@color/neutral_lighter_off_white"
                 android:textSize="14sp"
                 app:layout_constraintBottom_toTopOf="@+id/button_join"

--- a/Skeddly/app/src/main/res/values-night/themes.xml
+++ b/Skeddly/app/src/main/res/values-night/themes.xml
@@ -1,7 +1,6 @@
 <resources xmlns:tools="http://schemas.android.com/tools">
     <!-- Base application theme. -->
-    <!--<style name="Base.Theme.Skeddly" parent="Theme.Material3.DayNight.NoActionBar">-->
-    <style name="Base.Theme.Skeddly" parent="Theme.AppCompat.Light.NoActionBar">
+    <style name="Base.Theme.Skeddly" parent="Theme.Material3.DayNight.NoActionBar">
         <!-- Customize your dark theme here. -->
         <!-- <item name="colorPrimary">@color/my_dark_primary</item> -->
     </style>

--- a/Skeddly/app/src/main/res/values/themes.xml
+++ b/Skeddly/app/src/main/res/values/themes.xml
@@ -1,7 +1,6 @@
 <resources xmlns:tools="http://schemas.android.com/tools">
     <!-- Base application theme. -->
-    <!--<style name="Base.Theme.Skeddly" parent="Theme.Material3.DayNight.NoActionBar">-->
-    <style name="Base.Theme.Skeddly" parent="Theme.AppCompat.Light.NoActionBar">
+    <style name="Base.Theme.Skeddly" parent="Theme.Material3.DayNight.NoActionBar">
         <!-- Customize your light theme here. -->
         <!-- <item name="colorPrimary">@color/my_light_primary</item> -->
     </style>


### PR DESCRIPTION
Material 3 buttons don't let you change the background colour (or not easily?). We changed the theme to AppCompat but if we just use AppCompatButton instead, we can set button background and not have to change the theme. This also fixes the appearance of the navbar.