### PR TITLE
feat: Repository classes

### DIFF
--- a/Skeddly/app/src/main/java/com/example/skeddly/business/Ticket.java
+++ b/Skeddly/app/src/main/java/com/example/skeddly/business/Ticket.java
@@ -15,6 +15,7 @@ import java.time.ZoneId;
  */
 public class Ticket extends DatabaseObject {
     private String userId;
+    private String eventId;
     private long ticketTime;
     @Nullable
     private CustomLocation location;
@@ -30,8 +31,9 @@ public class Ticket extends DatabaseObject {
      * @param userId The id of the user that this ticket is associated with
      * @param location The location that the user is casting the ticket from, or NULL if not given.
      */
-    public Ticket(@NonNull String userId, @Nullable CustomLocation location) {
+    public Ticket(@NonNull String userId, @NonNull String eventId, @Nullable CustomLocation location) {
         this.userId = userId;
+        this.eventId = eventId;
         this.location = location;
         this.status = TicketStatus.INVITED;
 
@@ -42,26 +44,43 @@ public class Ticket extends DatabaseObject {
     /**
      * Constructor for a Ticket without location.
      * @param userId The id of the user that this ticket is associated with
+     * @param eventId The id of the event that this ticket is associated with
      */
-    public Ticket(@NonNull String userId) {
-        this(userId, null);
+    public Ticket(@NonNull String userId, @NonNull String eventId) {
+        this(userId, eventId, null);
     }
 
     /**
-     * Gets the user who entered the event.
+     * Gets the user id who entered the event.
      * @return The user id which entered the event
      */
     @NonNull
-    public String getUser() {
+    public String getUserId() {
         return userId;
     }
 
     /**
-     * Sets the user who entered the event.
+     * Sets the user id who entered the event.
      * @param userId The new id of the user that this ticket is associated with
      */
-    public void setUser(String userId) {
+    public void setUserId(String userId) {
         this.userId = userId;
+    }
+
+    /**
+     * Gets the event id that this ticket is associated with.
+     * @return The event id that this ticket is associated with.
+     */
+    public String getEventId() {
+        return eventId;
+    }
+
+    /**
+     * Sets the event id that this ticket is associated with.
+     * @param eventId The new event id that this ticket is associated with.
+     */
+    public void setEventId(String eventId) {
+        this.eventId = eventId;
     }
 
     /**

--- a/Skeddly/app/src/main/java/com/example/skeddly/business/database/repository/EventRepository.java
+++ b/Skeddly/app/src/main/java/com/example/skeddly/business/database/repository/EventRepository.java
@@ -1,0 +1,49 @@
+package com.example.skeddly.business.database.repository;
+
+
+import androidx.annotation.NonNull;
+
+import com.example.skeddly.business.event.Event;
+import com.google.android.gms.tasks.Continuation;
+import com.google.android.gms.tasks.Task;
+import com.google.firebase.firestore.CollectionReference;
+import com.google.firebase.firestore.FirebaseFirestore;
+import com.google.firebase.firestore.QuerySnapshot;
+
+import java.util.List;
+
+/**
+ * A class to handle retrieving events from Firestore.
+ */
+public class EventRepository extends GenericRepository<Event> {
+    private final FirebaseFirestore firestore;
+    public static final String COLLECTION_PATH = "events";
+
+    /**
+     * Creates a new event repository.
+     * @param firestore The FirebaseFirestore instance to use.
+     */
+    public EventRepository(FirebaseFirestore firestore) {
+        super(Event.class);
+        this.firestore = firestore;
+    }
+
+    /**
+     * Gets all events that are owned by the specified organizer.
+     * @param organizerId The ID of the organizer
+     * @return A task that returns all the events associated with the organizer in a list.
+     */
+    public Task<List<Event>> getAll(String organizerId) {
+        return getQuery().whereEqualTo("organizer", organizerId).get().continueWith(new Continuation<QuerySnapshot, List<Event>>() {
+            @Override
+            public List<Event> then(@NonNull Task<QuerySnapshot> task) throws Exception {
+                return task.getResult().toObjects(clazz);
+            }
+        });
+    }
+
+    @Override
+    protected CollectionReference getCollectionPath() {
+        return firestore.collection(COLLECTION_PATH);
+    }
+}

--- a/Skeddly/app/src/main/java/com/example/skeddly/business/database/repository/GenericRepository.java
+++ b/Skeddly/app/src/main/java/com/example/skeddly/business/database/repository/GenericRepository.java
@@ -1,0 +1,186 @@
+package com.example.skeddly.business.database.repository;
+
+import android.util.Log;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
+import com.example.skeddly.business.database.DatabaseObject;
+import com.example.skeddly.business.database.SingleListenUpdate;
+import com.google.android.gms.tasks.Continuation;
+import com.google.android.gms.tasks.RuntimeExecutionException;
+import com.google.android.gms.tasks.Task;
+import com.google.firebase.firestore.AggregateQuerySnapshot;
+import com.google.firebase.firestore.AggregateSource;
+import com.google.firebase.firestore.CollectionReference;
+import com.google.firebase.firestore.DocumentSnapshot;
+import com.google.firebase.firestore.EventListener;
+import com.google.firebase.firestore.FirebaseFirestoreException;
+import com.google.firebase.firestore.ListenerRegistration;
+import com.google.firebase.firestore.Query;
+import com.google.firebase.firestore.QuerySnapshot;
+
+import java.util.List;
+
+/**
+ * Represents a generic repository that can be extended to retrieve POJOs from Firestore.
+ * This class should NOT be used on its own. Derived classes should be used.
+ * @param <T> The class of objects that this repository shall handle.
+ */
+abstract class GenericRepository<T extends DatabaseObject> {
+    protected final Class<T> clazz;
+
+    /**
+     * Create a new GenericRepository with the given class as the type of POJO that it shall handle.
+     * @param clazz The class corresponding to the POJO we're dealing with.
+     */
+    protected GenericRepository(Class<T> clazz) {
+        this.clazz = clazz;
+    }
+
+    /**
+     * This method retrieves the reference to the collection of documents it handles
+     * @return A CollectionReference to the collection of documents it handles.
+     */
+    protected abstract CollectionReference getCollectionPath();
+
+    /**
+     * This method retrieves a query for getting all the documents handled by this repository.
+     * This is commonly overridden in repositories that filter out documents by fields.
+     * @return A query that can retrieve multiple documents.
+     */
+    protected Query getQuery() {
+        return getCollectionPath();
+    }
+
+    /**
+     * Retrieves a document by its ID. A task is returned that retrieves the object as converted to
+     * the POJO. Retrieving a document that does not exist will result in the task failing.
+     * <p>
+     * Common usage includes adding an onCompleteListener. The status of the task should be checked
+     * with a call to .isSuccessful() before attempting to retrieve the object.
+     *
+     * @param id The ID of the document we want to retrieve.
+     * @return A task that returns the requested object.
+     */
+    public Task<T> get(String id) {
+        return getCollectionPath().document(id).get().continueWith(new Continuation<DocumentSnapshot, T>() {
+            @Override
+            public T then(@NonNull Task<DocumentSnapshot> task) throws RuntimeExecutionException {
+                DocumentSnapshot documentSnapshot = task.getResult();
+
+                if (!documentSnapshot.exists()) {
+                    throw new RuntimeExecutionException(new Throwable("Not found"));
+                }
+
+                return task.getResult().toObject(clazz);
+            }
+        });
+    }
+
+    /**
+     * Retrieves all documents present in the collection managed by this repository. The documents
+     * are converted to their underlying POJOs and then returned as a list. The list shall be empty
+     * if the collection does not exist or has nothing in it.
+     * @return A task that returns all the objects in a list.
+     */
+    public Task<List<T>> getAll() {
+        return getQuery().get().continueWith(new Continuation<QuerySnapshot, List<T>>() {
+            @Override
+            public List<T> then(@NonNull Task<QuerySnapshot> task) throws Exception {
+                return task.getResult().toObjects(clazz);
+            }
+        });
+    }
+
+    /**
+     * Given an object, either update or add it to the repository. The ID of the object will be
+     * queried and used as the Document ID in the database.
+     * @param object The object to store in the repository.
+     * @return A task that will complete once the object has been saved.
+     */
+    public Task<Void> set(T object) {
+        return getCollectionPath().document(object.getId()).set(object);
+    }
+
+    /**
+     * Listens to the document given by the ID. The caller is called back with the initial state
+     * of the document as converted to a POJO. Any new changes afterwards will notify
+     * the provided callback function.
+     * <p>
+     * If the document does not exist when initially calling this, the returned object is NULL.
+     * The listener remains active and will notify if the document is created later on.
+     * <p>
+     * If the document is deleted, the returned object is NULL. The listener still remains active
+     * for if a document with the same ID is created.
+     * <p>
+     * Warning: The caller is responsible for removing the ListenerRegistration once they no longer
+     * require updates. Only use this method if real time updates are necessary.
+     * @param id The ID of the document we want to listen to.
+     * @param callback Who we should call back upon document changes.
+     * @return A ListenerRegistration object that can be used to cancel the listener at any time.
+     */
+    public ListenerRegistration listen(String id, SingleListenUpdate<T> callback) {
+        return getCollectionPath().document(id).addSnapshotListener(new EventListener<DocumentSnapshot>() {
+            @Override
+            public void onEvent(@Nullable DocumentSnapshot value, @Nullable FirebaseFirestoreException error) {
+                if (value != null) {
+                    Log.v("GenericRepository", String.format("Retrieved update for '%s/%s'", getCollectionPath().getId(), id));
+                    callback.onUpdate(value.toObject(clazz));
+                }
+            }
+        });
+    }
+
+    /**
+     * Listens to all documents in this repository. The caller is called back with the initial state
+     * of all documents as converted to POJOs. Any new changes afterwards will notify the provided
+     * callback function. Note that each call provides a list of every object, even those that did
+     * not change.
+     * <p>
+     * If the collection does not exist when initially calling this, the list is empty.
+     * The listener remains active and will notify if the collection is added to later on.
+     * <p>
+     * Warning: The caller is responsible for removing the ListenerRegistration once they no longer
+     * require updates. Only use this method if real time updates are necessary.
+     *
+     * @param callback Who we should call back upon document changes.
+     * @return A ListenerRegistration object that can be used to cancel the listener at any time.
+     */
+    public ListenerRegistration listenAll(SingleListenUpdate<List<T>> callback) {
+        return getQuery().addSnapshotListener(new EventListener<QuerySnapshot>() {
+            @Override
+            public void onEvent(@Nullable QuerySnapshot value, @Nullable FirebaseFirestoreException error) {
+                if (value != null) {
+                    callback.onUpdate(value.toObjects(clazz));
+                }
+            }
+        });
+    }
+
+    /**
+     * Deletes a document by its ID. A task is returned that can be listened to so that the caller
+     * knows when the deletion has finished being processed by the DB.
+     * <p>
+     * If the ID does not exist in the database, the task is still successful and nothing changes.
+     * @param id The ID of the document that we want to delete.
+     * @return A listenable Task that represents the deletion on the DB side.
+     */
+    public Task<Void> delete(String id) {
+        return getCollectionPath().document(id).delete();
+    }
+
+    /**
+     * Counts the number of documents that reside within the collection we are tracking.
+     * If the collection does not exist, a count of 0 is returned.
+     * @return A task that retrieves the count as a long.
+     */
+    public Task<Long> count() {
+        return getQuery().count().get(AggregateSource.SERVER).continueWith(new Continuation<AggregateQuerySnapshot, Long>() {
+            @Override
+            public Long then(@NonNull Task<AggregateQuerySnapshot> task) throws Exception {
+                return task.getResult().getCount();
+            }
+        });
+    }
+}

--- a/Skeddly/app/src/main/java/com/example/skeddly/business/database/repository/NotificationRepository.java
+++ b/Skeddly/app/src/main/java/com/example/skeddly/business/database/repository/NotificationRepository.java
@@ -1,0 +1,54 @@
+package com.example.skeddly.business.database.repository;
+
+import androidx.annotation.Nullable;
+
+import com.example.skeddly.business.notification.Notification;
+import com.google.firebase.firestore.CollectionReference;
+import com.google.firebase.firestore.FirebaseFirestore;
+import com.google.firebase.firestore.Query;
+
+/**
+ * A class to handle retrieving notifications from Firestore. This class is (typically) associated
+ * with a particular user, which is relevant when performing aggregate retrievals.
+ */
+public class NotificationRepository extends GenericRepository<Notification> {
+    private final FirebaseFirestore firestore;
+    @Nullable
+    private final String userId;
+    public static final String COLLECTION_PATH = "tickets";
+
+    /**
+     * Create a new NotificationRepository. The repository is associated with a particular user,
+     * unless the provided userId is null. If it is, the repository shall retrieve all notifications
+     * for any user.
+     * @param firestore The FirebaseFirestore instance to use.
+     * @param userId The user id that this repository is associated with.
+     */
+    public NotificationRepository(FirebaseFirestore firestore, @Nullable String userId) {
+        super(Notification.class);
+        this.firestore = firestore;
+        this.userId = userId;
+    }
+
+    /**
+     * Create a new NotificationRepository that is not tied to a specific user.
+     * @param firestore The FirebaseFirestore instance to use.
+     */
+    public NotificationRepository(FirebaseFirestore firestore) {
+        this(firestore, null);
+    }
+
+    @Override
+    protected CollectionReference getCollectionPath() {
+        return firestore.collection(COLLECTION_PATH);
+    }
+
+    @Override
+    protected Query getQuery() {
+        if (userId == null) {
+            return super.getQuery();
+        }
+
+        return getCollectionPath().whereEqualTo("recipient", userId);
+    }
+}

--- a/Skeddly/app/src/main/java/com/example/skeddly/business/database/repository/TicketRepository.java
+++ b/Skeddly/app/src/main/java/com/example/skeddly/business/database/repository/TicketRepository.java
@@ -1,0 +1,33 @@
+package com.example.skeddly.business.database.repository;
+
+
+import com.example.skeddly.business.Ticket;
+import com.google.firebase.firestore.CollectionReference;
+import com.google.firebase.firestore.FirebaseFirestore;
+import com.google.firebase.firestore.Query;
+
+/**
+ * A class to handle retrieving tickets from Firestore. This class is associated with a particular
+ * event, which is relevant when performing aggregate retrievals.
+ */
+public class TicketRepository extends GenericRepository<Ticket> {
+    private final FirebaseFirestore firestore;
+    private final String eventId;
+    public static final String COLLECTION_PATH = "tickets";
+
+    public TicketRepository(FirebaseFirestore firestore, String eventId) {
+        super(Ticket.class);
+        this.firestore = firestore;
+        this.eventId = eventId;
+    }
+
+    @Override
+    protected CollectionReference getCollectionPath() {
+        return firestore.collection(COLLECTION_PATH);
+    }
+
+    @Override
+    protected Query getQuery() {
+        return getCollectionPath().whereEqualTo("eventId", eventId);
+    }
+}

--- a/Skeddly/app/src/main/java/com/example/skeddly/business/event/Event.java
+++ b/Skeddly/app/src/main/java/com/example/skeddly/business/event/Event.java
@@ -228,7 +228,7 @@ public class Event extends DatabaseObject {
         }
 
         // Create a new ticket for the user
-        Ticket ticket = new Ticket(userId, location);
+        Ticket ticket = new Ticket(userId, getId(), location);
 
         // Add the ticket's ID to the event's applicants list
         this.getWaitingList().addTicket(ticket.getId());

--- a/Skeddly/app/src/main/java/com/example/skeddly/business/notification/Notification.java
+++ b/Skeddly/app/src/main/java/com/example/skeddly/business/notification/Notification.java
@@ -3,6 +3,7 @@ package com.example.skeddly.business.notification;
 import com.example.skeddly.business.database.DatabaseObject;
 
 import java.time.LocalDateTime;
+import java.time.ZoneId;
 
 /**
  * Represents a single notification item within the application.
@@ -12,21 +13,24 @@ public class Notification extends DatabaseObject {
     // Fields for the notification object
     private String title;
     private String message;
-    private LocalDateTime timestamp;
-    private NotificationType type;
+    private String recipient;
     private String eventId; // Used to link to a specific event
-    private boolean isRead;
+    private long timestamp;
+    private NotificationType type;
     private NotificationInvitationStatus status; // Specific to invitation notifications
+    private boolean read;
 
     /**
      * Default constructor for creating a new Notification.
      * Sets its read status to false and status to pending.
      */
     public Notification() {
-//        this.timestamp = LocalDateTime.now();
-        this.isRead = false;
+        this.read = false;
         this.status = NotificationInvitationStatus.PENDING;
         this.type = NotificationType.MESSAGES;
+
+        ZoneId zoneId = ZoneId.systemDefault();
+        this.timestamp = LocalDateTime.now().atZone(zoneId).toEpochSecond();
     }
 
     /**
@@ -34,10 +38,11 @@ public class Notification extends DatabaseObject {
      * @param title The title to set on the notification.
      * @param message The message that it should contain.
      */
-    public Notification(String title, String message) {
+    public Notification(String title, String message, String recipient) {
         this();
         this.setTitle(title);
         this.setMessage(message);
+
     }
 
     /**
@@ -54,6 +59,22 @@ public class Notification extends DatabaseObject {
      */
     public void setTitle(String title) {
         this.title = title;
+    }
+
+    /**
+     * Gets the recipient of the notification.
+     * @return The user id of the recipient
+     */
+    public String getRecipient() {
+        return recipient;
+    }
+
+    /**
+     * Sets the recipient of the notification.
+     * @param recipient The user id of the recipient
+     */
+    public void setRecipient(String recipient) {
+        this.recipient = recipient;
     }
 
     /**
@@ -76,17 +97,17 @@ public class Notification extends DatabaseObject {
      * Gets the timestamp indicating when the notification was created.
      * @return A Date object representing the creation time.
      */
-//    public LocalDateTime getTimestamp() {
-//        return LocalDateTime.now();
-//    }
+    public long getTimestamp() {
+        return timestamp;
+    }
 
     /**
      * Sets the timestamp for the notification.
      * @param timestamp The Date to set.
      */
-//    public void setTimestamp(LocalDateTime timestamp) {
-//        this.timestamp = timestamp;
-//    }
+    public void setTimestamp(long timestamp) {
+        this.timestamp = timestamp;
+    }
 
     /**
      * Gets the type of the notification.
@@ -125,7 +146,7 @@ public class Notification extends DatabaseObject {
      * @return A boolean, true if read, false otherwise.
      */
     public boolean isRead() {
-        return isRead;
+        return read;
     }
 
     /**
@@ -133,7 +154,7 @@ public class Notification extends DatabaseObject {
      * @param read The boolean status to set.
      */
     public void setRead(boolean read) {
-        isRead = read;
+        this.read = read;
     }
 
     /**

--- a/Skeddly/app/src/main/java/com/example/skeddly/ui/TestFragment.java
+++ b/Skeddly/app/src/main/java/com/example/skeddly/ui/TestFragment.java
@@ -17,11 +17,15 @@ import androidx.annotation.Nullable;
 import androidx.fragment.app.Fragment;
 import androidx.fragment.app.FragmentResultListener;
 
+import com.example.skeddly.business.database.repository.EventRepository;
 import com.example.skeddly.databinding.FragmentTestBinding;
 import com.example.skeddly.ui.popup.MapPopupDialogFragment;
 import com.example.skeddly.ui.popup.QRPopupDialogFragment;
 import com.example.skeddly.ui.popup.StandardPopupDialogFragment;
 import com.google.android.gms.maps.model.LatLng;
+import com.google.android.gms.tasks.OnCompleteListener;
+import com.google.android.gms.tasks.Task;
+import com.google.firebase.firestore.FirebaseFirestore;
 
 
 /**
@@ -37,11 +41,11 @@ public class TestFragment extends Fragment {
         binding = FragmentTestBinding.inflate(inflater, container, false);
         View root = binding.getRoot();
 
-        TextView returnText = binding.returnText;
-        ImageView photoPickerImage = binding.photoPickerImage;
+        TextView returnText = binding.textReturn;
+        ImageView photoPickerImage = binding.imgPickerPhoto;
 
         // === Generic popup stuff ===
-        Button testButton = binding.testButton;
+        Button testButton = binding.btnPopup;
         testButton.setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View view) {
@@ -100,7 +104,7 @@ public class TestFragment extends Fragment {
 //        });
 
         // === Location Picker Stuff ===
-        Button locationPickerButton = binding.locationPickerButton;
+        Button locationPickerButton = binding.btnPickerLocation;
         locationPickerButton.setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View view) {
@@ -133,7 +137,7 @@ public class TestFragment extends Fragment {
             }
         });
 
-        Button photoPickerButton = binding.photoPickerButton;
+        Button photoPickerButton = binding.btnPickerPhoto;
         photoPickerButton.setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View view) {
@@ -155,7 +159,7 @@ public class TestFragment extends Fragment {
         });
 
         // === QR Code stuff ===
-        Button qrButton = binding.qrButton;
+        Button qrButton = binding.btnQrDialog;
         qrButton.setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View v) {
@@ -163,6 +167,101 @@ public class TestFragment extends Fragment {
                 qpf.show(getChildFragmentManager(), null);
             }
         });
+
+        // === DB Random stuff ===
+        Button dbButton = binding.btnDb;
+        EventRepository eventRepository = new EventRepository(FirebaseFirestore.getInstance());
+        dbButton.setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View v) {
+//                eventRepository.getAll().addOnCompleteListener(new OnCompleteListener<List<Event>>() {
+//                    @Override
+//                    public void onComplete(@NonNull Task<List<Event>> task) {
+//                        Log.v("TEST_DB_BTN_GET_ALL", "Callback received!");
+//
+//                        if (!task.isSuccessful()) {
+//                            Log.v("TEST_DB_BTN_GET_ALL", "Task failed!");
+//                        } else {
+//                            for (Event event : task.getResult()) {
+//                                Log.v("TEST_DB_BTN_GET_ALL", event.getId());
+//                            }
+//                            Log.v("TEST_DB_BTN_GET_ALL", "Printed all IDs!");
+//                        }
+//
+//
+//                    }
+//                });
+
+//                eventRepository.listenAll(new SingleListenUpdate<List<Event>>() {
+//                    @Override
+//                    public void onUpdate(List<Event> newValue) {
+//                        Log.v("TEST_DB_BTN_LISTEN_ALL", "Callback received!");
+//
+//                        for (Event event : newValue) {
+//                            Log.v("TEST_DB_BTN_LISTEN_ALL", event.getId());
+//                        }
+//                    }
+//                });
+
+
+//                eventRepository.count().addOnCompleteListener(new OnCompleteListener<Long>() {
+//                    @Override
+//                    public void onComplete(@NonNull Task<Long> task) {
+//                        Log.v("TEST_DB_BTN_COUNT", "Callback received!");
+//
+//                        if (task.isSuccessful()) {
+//                            Log.v("TEST_DB_BTN_COUNT", Long.toString(task.getResult()));
+//                        } else {
+//                            Log.v("TEST_DB_BTN_COUNT", "Task failed!");
+//                        }
+//                    }
+//                });
+//
+//                eventRepository.listenById("69", new SingleListenUpdate<Event>() {
+//                    @Override
+//                    public void onUpdate(Event newValue) {
+//                        Log.v("TEST_DB_BTN_LISTEN", "Callback received!");
+//
+//                        if (newValue == null) {
+//                            Log.v("TEST_DB_BTN_LISTEN", "Got null!");
+//                        } else {
+//                            Log.v("TEST_DB_BTN_LISTEN", newValue.getId());
+//                        }
+//                    }
+//                });
+
+//                eventRepository.getById("67").addOnCompleteListener(new OnCompleteListener<Event>() {
+//                    @Override
+//                    public void onComplete(@NonNull Task<Event> task) {
+//                        Log.v("TEST_DB_BTN_GET", "Callback received!");
+//
+//                        if (!task.isSuccessful()) {
+//                            Log.v("TEST_DB_BTN_GET", "Task failed!");
+//                        } else {
+//                            Log.v("TEST_DB_BTN_GET", task.getResult().getId());
+//                        }
+//                    }
+//                });
+
+//                Task<Void> asd = eventRepository.delete("67");
+//
+//                asd.addOnCompleteListener(new OnCompleteListener<Void>() {
+//                    @Override
+//                    public void onComplete(@NonNull Task<Void> task) {
+//                        Log.v("TEST_DB_BTN_DELETE", "Deleting task completed!");
+//
+//                        if (task.isSuccessful()) {
+//                            Log.v("TEST_DB_BTN_DELETE", "Deleting task was successful!");
+//                        } else if (task.isCanceled()) {
+//                            Log.v("TEST_DB_BTN_DELETE", "Deleting task was cancelled!");
+//                        } else {
+//                            Log.v("TEST_DB_BTN_DELETE", "Deleting task was not successful!");
+//                        }
+//                    }
+//                });
+            }
+        });
+
 
         return root;
     }

--- a/Skeddly/app/src/main/java/com/example/skeddly/ui/adapter/ParticipantAdapter.java
+++ b/Skeddly/app/src/main/java/com/example/skeddly/ui/adapter/ParticipantAdapter.java
@@ -66,7 +66,7 @@ public class ParticipantAdapter extends ArrayAdapter<Ticket> {
         Ticket ticket = getItem(position);
         if (ticket != null) {
             // Set user name
-            getUserFromId(ticket.getUser(), user -> {
+            getUserFromId(ticket.getUserId(), user -> {
                 fullname = user.getPersonalInformation().getName();
                 nameText.setText(fullname);
             });

--- a/Skeddly/app/src/main/res/layout/fragment_test.xml
+++ b/Skeddly/app/src/main/res/layout/fragment_test.xml
@@ -5,82 +5,109 @@
     android:layout_width="match_parent"
     android:layout_height="match_parent">
 
-
-    <Button
-        android:id="@+id/testButton"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_marginStart="16dp"
-        android:layout_marginBottom="16dp"
-        android:text="Popup"
-        app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintStart_toStartOf="parent" />
-
-    <Button
-        android:id="@+id/timePickerButton"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:text="Time Picker"
-        app:layout_constraintBottom_toBottomOf="@+id/testButton"
-        app:layout_constraintEnd_toStartOf="@+id/locationPickerButton"
-        app:layout_constraintStart_toEndOf="@+id/testButton" />
-
-    <Button
-        android:id="@+id/datePickerButton"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:text="Date Picker"
-        app:layout_constraintBottom_toTopOf="@+id/timePickerButton"
-        app:layout_constraintEnd_toEndOf="@+id/timePickerButton"
-        app:layout_constraintStart_toStartOf="@+id/timePickerButton" />
-
-    <Button
-        android:id="@+id/locationPickerButton"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_marginEnd="16dp"
-        android:text="Location Picker"
-        app:layout_constraintBottom_toBottomOf="@+id/testButton"
-        app:layout_constraintEnd_toEndOf="parent" />
-
-    <Button
-        android:id="@+id/photoPickerButton"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:text="Photo Picker"
-        app:layout_constraintBottom_toTopOf="@+id/locationPickerButton"
-        app:layout_constraintEnd_toEndOf="@+id/locationPickerButton"
-        app:layout_constraintStart_toStartOf="@+id/locationPickerButton" />
-
-    <Button
-        android:id="@+id/qrButton"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:text="QR Code"
-        app:layout_constraintBottom_toTopOf="@+id/testButton"
-        app:layout_constraintEnd_toEndOf="@+id/testButton"
-        app:layout_constraintStart_toStartOf="@+id/testButton" />
-
-    <ImageView
-        android:id="@+id/photoPickerImage"
-        android:layout_width="0dp"
-        android:layout_height="0dp"
-        android:src="@drawable/ic_event_history"
-        app:layout_constraintBottom_toTopOf="@+id/datePickerButton"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@+id/returnText" />
-
     <TextView
-        android:id="@+id/returnText"
+        android:id="@+id/text_return"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:layout_marginTop="16dp"
         android:text="Hello world!"
         android:textAlignment="center"
         android:textSize="18sp"
-        app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent" />
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintBottom_toTopOf="@id/img_picker_photo"/>
+
+    <ImageView
+        android:id="@+id/img_picker_photo"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        android:src="@drawable/ic_event_history"
+        app:layout_constraintTop_toBottomOf="@+id/text_return"
+        app:layout_constraintBottom_toTopOf="@+id/layout_btns"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent" />
+
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:id="@+id/layout_btns"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        app:layout_constraintTop_toBottomOf="@id/img_picker_photo"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent">
+
+        <Button
+            android:id="@+id/btn_popup"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="Popup"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent"/>
+
+        <Button
+            android:id="@+id/btn_qr_dialog"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="QR Code"
+            app:layout_constraintStart_toEndOf="@id/btn_popup"
+            app:layout_constraintEnd_toStartOf="@id/btn_db"
+            app:layout_constraintTop_toTopOf="parent"
+            />
+
+        <Button
+            android:id="@+id/btn_db"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="Database Test"
+            app:layout_constraintStart_toEndOf="@id/btn_qr_dialog"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintTop_toTopOf="parent"
+            />
+
+        <Button
+            android:id="@+id/btn_picker_date"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="Date Picker"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintEnd_toStartOf="@id/btn_picker_time"
+            app:layout_constraintTop_toBottomOf="@id/btn_popup"
+            />
+
+        <Button
+            android:id="@+id/btn_picker_time"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="Time Picker"
+            app:layout_constraintStart_toEndOf="@id/btn_picker_date"
+            app:layout_constraintEnd_toStartOf="@id/btn_picker_location"
+            app:layout_constraintBaseline_toBaselineOf="@id/btn_picker_date"
+            />
+
+        <Button
+            android:id="@+id/btn_picker_location"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginEnd="16dp"
+            android:text="Location Picker"
+            app:layout_constraintStart_toEndOf="@id/btn_picker_time"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintBaseline_toBaselineOf="@id/btn_picker_time"
+            />
+
+        <Button
+            android:id="@+id/btn_picker_photo"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="Photo Picker"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/btn_picker_date"
+            />
+
+
+
+
+
+    </androidx.constraintlayout.widget.ConstraintLayout>
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/Skeddly/app/src/test/java/com/example/skeddly/business/TicketUnitTest.java
+++ b/Skeddly/app/src/test/java/com/example/skeddly/business/TicketUnitTest.java
@@ -17,17 +17,17 @@ public class TicketUnitTest {
     @Test
     public void testTicketUserLinked() {
         User user = new User();
-        Ticket ticket = new Ticket(user.getId());
+        Ticket ticket = new Ticket(user.getId(), "");
 
-        assertSame(ticket.getUser(), user.getId());
+        assertSame(ticket.getUserId(), user.getId());
     }
 
     @Test
     public void testTicketLocation() {
         User user = new User();
         CustomLocation location = new CustomLocation(0, 0);
-        Ticket ticketLocation = new Ticket(user.getId(), location);
-        Ticket ticketNoLocation = new Ticket(user.getId());
+        Ticket ticketLocation = new Ticket(user.getId(), "", location);
+        Ticket ticketNoLocation = new Ticket(user.getId(), "");
 
         assertNotNull(ticketLocation.getLocation());
         assertNull(ticketNoLocation.getLocation());
@@ -36,7 +36,7 @@ public class TicketUnitTest {
     @Test
     public void testTicketTime() {
         User user = new User();
-        Ticket ticket = new Ticket(user.getId());
+        Ticket ticket = new Ticket(user.getId(), "");
 
         ZoneId zoneId = ZoneId.systemDefault();
         long curEpoch = LocalDateTime.now().atZone(zoneId).toEpochSecond();


### PR DESCRIPTION
These classes can be used to more easily fetch data from Firestore. They are as well documented as I could possibly make them so that they are easy to understand.

Existing code does not use these repositories but we can use them going forward and maybe go back later to change old stuff.

The classes have detailed javadocs showing how they can be used. The derived repositories (like EventRepository, TicketRepository, etc) all extend GenericRepository. Most of the javadocs are in there (most methods are inherited).

Most of the methods do not accept a callback as a parameter, but instead return a `Task` object. You can then attach an `onCompletedListener` to them to listen for when the task is completed.

We can add more repositories and specialized methods as needed.