### PR TITLE
refactor: Don't store notifications directly in the user

### DIFF
--- a/Skeddly/app/src/main/java/com/example/skeddly/business/database/repository/GenericRepository.java
+++ b/Skeddly/app/src/main/java/com/example/skeddly/business/database/repository/GenericRepository.java
@@ -27,7 +27,7 @@ import java.util.List;
  * This class should NOT be used on its own. Derived classes should be used.
  * @param <T> The class of objects that this repository shall handle.
  */
-abstract class GenericRepository<T extends DatabaseObject> {
+public abstract class GenericRepository<T extends DatabaseObject> {
     protected final Class<T> clazz;
 
     /**

--- a/Skeddly/app/src/main/java/com/example/skeddly/business/database/repository/NotificationRepository.java
+++ b/Skeddly/app/src/main/java/com/example/skeddly/business/database/repository/NotificationRepository.java
@@ -15,7 +15,7 @@ public class NotificationRepository extends GenericRepository<Notification> {
     private final FirebaseFirestore firestore;
     @Nullable
     private final String userId;
-    public static final String COLLECTION_PATH = "tickets";
+    public static final String COLLECTION_PATH = "notifications";
 
     /**
      * Create a new NotificationRepository. The repository is associated with a particular user,

--- a/Skeddly/app/src/main/java/com/example/skeddly/business/database/repository/RepositoryToArrayAdapter.java
+++ b/Skeddly/app/src/main/java/com/example/skeddly/business/database/repository/RepositoryToArrayAdapter.java
@@ -1,0 +1,82 @@
+package com.example.skeddly.business.database.repository;
+
+import android.widget.ArrayAdapter;
+
+import androidx.annotation.NonNull;
+
+import com.example.skeddly.business.database.DatabaseObject;
+import com.example.skeddly.business.database.SingleListenUpdate;
+import com.google.android.gms.tasks.OnCompleteListener;
+import com.google.android.gms.tasks.Task;
+import com.google.firebase.firestore.ListenerRegistration;
+
+import java.util.List;
+
+/**
+ * This classes uses a given repository to supply data to an ArrayAdapter.
+ * @param <T> The type of object that this adapter shall manage.
+ */
+public class RepositoryToArrayAdapter<T extends DatabaseObject> {
+    private final GenericRepository<T> repository;
+    private final ArrayAdapter<T> adapter;
+    private ListenerRegistration listener;
+
+    /**
+     * Create a new RepositoryToArrayAdapter. Real time updates are an option via the boolean.
+     * <p>
+     * Warning: If using the real time updates, the caller must ensure to remove the real time
+     * listener via the removeListener() method once updates are no longer required. This can be
+     * done inside the onDestroyView() function for example.
+     * @param repository The repository that shall be queried for data
+     * @param adapter The adapter to add data to
+     * @param realtimeUpdates Whether we should use real time updates for data.
+     */
+    public RepositoryToArrayAdapter(GenericRepository<T> repository, ArrayAdapter<T> adapter, boolean realtimeUpdates) {
+        this.repository = repository;
+        this.adapter = adapter;
+        this.listener = null;
+
+        setupListener(realtimeUpdates);
+    }
+
+    /**
+     * Sets up the array adapter with the data by querying the repository.
+     * @param realtimeUpdates Whether real time updates should be used.
+     */
+    private void setupListener(boolean realtimeUpdates) {
+        adapter.clear();
+
+        if (realtimeUpdates) {
+            listener = repository.listenAll(new SingleListenUpdate<List<T>>() {
+                @Override
+                public void onUpdate(List<T> newValue) {
+                    adapter.clear();
+                    adapter.addAll(newValue);
+                    adapter.notifyDataSetChanged();
+                }
+            });
+        } else {
+            repository.getAll().addOnCompleteListener(new OnCompleteListener<List<T>>() {
+                @Override
+                public void onComplete(@NonNull Task<List<T>> task) {
+                    if (task.isSuccessful()) {
+                        adapter.addAll(task.getResult());
+                        adapter.notifyDataSetChanged();
+                    }
+                }
+            });
+        }
+    }
+
+    /**
+     * Removes the real time listener if one is present. If one is not present, or the listener
+     * has already been removed, nothing happens.
+     */
+    public void removeListener() {
+        if (listener != null) {
+            listener.remove();
+            listener = null;
+        }
+
+    }
+}

--- a/Skeddly/app/src/main/java/com/example/skeddly/business/notification/Notification.java
+++ b/Skeddly/app/src/main/java/com/example/skeddly/business/notification/Notification.java
@@ -37,12 +37,13 @@ public class Notification extends DatabaseObject {
      * Construct a notification with the given title and message.
      * @param title The title to set on the notification.
      * @param message The message that it should contain.
+     * @param recipient The user id of the recipient of the message.
      */
     public Notification(String title, String message, String recipient) {
         this();
         this.setTitle(title);
         this.setMessage(message);
-
+        this.setRecipient(recipient);
     }
 
     /**

--- a/Skeddly/app/src/main/java/com/example/skeddly/business/user/User.java
+++ b/Skeddly/app/src/main/java/com/example/skeddly/business/user/User.java
@@ -1,9 +1,7 @@
 package com.example.skeddly.business.user;
 
 import com.example.skeddly.business.database.DatabaseObject;
-import com.example.skeddly.business.database.DatabaseObjects;
 import com.example.skeddly.business.event.Event;
-import com.example.skeddly.business.notification.Notification;
 import com.google.firebase.firestore.Exclude;
 
 import java.util.ArrayList;
@@ -17,7 +15,6 @@ public class User extends DatabaseObject {
     private ArrayList<String> ownedEvents;
     private ArrayList<String> joinedEvents;
     private UserLevel privilegeLevel;
-    private DatabaseObjects<Notification> notifications;
 
     /**
      * Constructor for the User
@@ -27,7 +24,6 @@ public class User extends DatabaseObject {
         this.personalInformation = new PersonalInformation();
         this.notificationSettings = new NotificationSettings();
         this.privilegeLevel = UserLevel.ENTRANT;
-        this.notifications = new DatabaseObjects<>(Notification.class);
     }
 
     /**
@@ -103,7 +99,7 @@ public class User extends DatabaseObject {
     }
 
     /**
-     * Getss the list of events the user has joined.
+     * Gets the list of events the user has joined.
      * @return An array list of event ids.
      */
     @Exclude // Exclude so we can handle ourselves
@@ -118,23 +114,5 @@ public class User extends DatabaseObject {
     @Exclude // Exclude so we can handle ourselves
     public void setJoinedEvents(ArrayList<String> joinedEvents) {
         this.joinedEvents = joinedEvents;
-    }
-
-    /**
-     * Gets the list of notifications that the user has
-     * @return DatabaseObjects list of notifications.
-     */
-    @Exclude // Exclude so we can handle ourselves
-    public DatabaseObjects<Notification> getNotifications() {
-        return notifications;
-    }
-
-    /**
-     * Sets the list of notifications
-     * @param notifications DatabaseObjects list of notifications.
-     */
-    @Exclude // Exclude so we can handle ourselves
-    public void setNotifications(DatabaseObjects<Notification> notifications) {
-        this.notifications = notifications;
     }
 }

--- a/Skeddly/app/src/main/java/com/example/skeddly/ui/adapter/InboxAdapter.java
+++ b/Skeddly/app/src/main/java/com/example/skeddly/ui/adapter/InboxAdapter.java
@@ -22,10 +22,10 @@ import java.util.List;
  * InboxAdapter is an ArrayAdapter of notifications that shows the inbox.
  */
 public class InboxAdapter extends ArrayAdapter<Notification> implements Filterable {
-    private List<Notification> originalNotifications;
-    private List<Notification> filteredNotifications;
+    private final List<Notification> originalNotifications;
+    private final List<Notification> filteredNotifications;
     private NotificationFilter filter;
-    private Context context;
+    private String lastFilter;
 
     /**
      * Constructor for the InboxAdapter.
@@ -34,9 +34,9 @@ public class InboxAdapter extends ArrayAdapter<Notification> implements Filterab
      */
     public InboxAdapter(Context context, ArrayList<Notification> notifs) {
         super(context, 0, notifs);
-        this.context = context;
-        this.originalNotifications = new ArrayList<>(notifs);
+        this.originalNotifications = notifs;
         this.filteredNotifications = new ArrayList<>(notifs);
+        this.lastFilter = "3";
     }
 
     /**
@@ -73,7 +73,7 @@ public class InboxAdapter extends ArrayAdapter<Notification> implements Filterab
     public View getView(int position, @Nullable View convertView, @NonNull ViewGroup parent){
         View view = convertView;
         if (view == null){
-            view = LayoutInflater.from(context).inflate(R.layout.item_notification, parent, false);
+            view = LayoutInflater.from(getContext()).inflate(R.layout.item_notification, parent, false);
         }
 
         Notification notif = getItem(position);
@@ -105,6 +105,7 @@ public class InboxAdapter extends ArrayAdapter<Notification> implements Filterab
 
         @Override
         protected FilterResults performFiltering(CharSequence constraint) {
+            lastFilter = constraint.toString();
             FilterResults results = new FilterResults();
             List<Notification> filteredList = new ArrayList<>();
 
@@ -137,5 +138,15 @@ public class InboxAdapter extends ArrayAdapter<Notification> implements Filterab
             }
             notifyDataSetChanged();
         }
+    }
+
+    @Override
+    public void notifyDataSetChanged() {
+        getFilter().filter(lastFilter, new Filter.FilterListener() {
+            @Override
+            public void onFilterComplete(int count) {
+                InboxAdapter.super.notifyDataSetChanged();
+            }
+        });
     }
 }


### PR DESCRIPTION
- New RepositoryToArrayAdapter class. This takes in a Repository and an ArrayAdapter. The ArrayAdapter is automatically populated with the contents of the repository. Real time updates are supported if desired (however you must be careful to remove the listener when you're done with it).
- Notifications are no longer stored in the user object. Instead, store them in a top-level collection in firebase. We can then query by the `recipient` attribute to receive all the ones related to us. This also makes sending notifications easier as senders can just add it to the collection with the `recipient` properly filled out.
- Tweak inbox fragment with the required changes